### PR TITLE
Fix raising exception about unsupported stream callbacks

### DIFF
--- a/lib/anycable/rails/actioncable/channel.rb
+++ b/lib/anycable/rails/actioncable/channel.rb
@@ -14,7 +14,9 @@ module ActionCable
       end
 
       def stream_from(broadcasting, callback = nil, coder: nil)
-        raise ArgumentError('Unsupported') if callback.present? || coder.present? || block_given?
+        if callback.present? || coder.present? || block_given?
+          raise ArgumentError, 'Custom stream callbacks are not supported in AnyCable!'
+        end
         connection.socket.subscribe identifier, broadcasting
       end
 


### PR DESCRIPTION
Exception classes are not methods.

```rb
raise ArgumentError('Unsupported')                                                    
# NoMethodError: undefined method `ArgumentError' for main:Object
```