### PR TITLE
Support request verification based on ActionCable config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.6.0-dev
 
+- [PR #56](https://github.com/anycable/anycable-rails/pull/56) Request verification based on ActionCable config. ([@DmitryTsepelev][])
+
 - Add WS server session ID to log tags if present. ([@palkan][])
 
 - Support tagged logging. ([@palkan][])

--- a/lib/anycable/rails/actioncable/connection.rb
+++ b/lib/anycable/rails/actioncable/connection.rb
@@ -47,13 +47,14 @@ module ActionCable
       end
 
       def handle_open
+        return reject_request unless allow_request_origin?
+
         logger.info started_request_message if access_logs?
 
         connect if respond_to?(:connect)
         send_welcome_message
       rescue ActionCable::Connection::Authorization::UnauthorizedError
-        logger.info finished_request_message("Rejected") if access_logs?
-        close
+        reject_request
       end
 
       def handle_close
@@ -151,7 +152,16 @@ module ActionCable
           ltags
         end
       end
+
+      def server
+        ActionCable.server
+      end
+
+      def reject_request
+        logger.info finished_request_message("Rejected") if access_logs?
+        close
+      end
     end
+    # rubocop:enable Metrics/ClassLength
   end
-  # rubocop: enable Metrics/ClassLength
 end


### PR DESCRIPTION
Addresses #31 - with this change `anycable-rails` will start verifying all incoming requests if that was configured for `ActionCable.server.config` (it accepts everything from `localhost:3000` in dev mode and can be configured via `disable_request_forgery_protection`, `allowed_request_origins` and `allow_same_origin_as_host`).

I've added a couple of specs to prove that change is working but I haven't covered all the cases since I'm just calling [#allow_request_origin?](https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/actioncable/lib/action_cable/connection/base.rb#L194) which has tests covering more complex cases.

Please let me know if the behavior for the rejected origins looks right.