### PR TITLE
fixed anycable config dependency

### DIFF
--- a/lib/anycable/rails/config.rb
+++ b/lib/anycable/rails/config.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+#
+
+require 'anycable/config'
 
 # Extend AnyCable configuration with
 # `access_logs_disabled` options (defaults to true)

--- a/lib/anycable/rails/config.rb
+++ b/lib/anycable/rails/config.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
-#
 
-require 'anycable/config'
+require "anycable/config"
 
 # Extend AnyCable configuration with
 # `access_logs_disabled` options (defaults to true)


### PR DESCRIPTION
This fixes an 'uninitialized constant AnyCable::Config' error by explicitly requesting 'anycable/config'.
