### PR TITLE
Add `:anycable` subscription adapter alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `:anycable` subscription adapter alias. ([@sponomarev][])
+
 - Don't set AnyCable connection factory for incompatible adapter ([@sponomarev][])
 
   `anycable` server won't start with unpatched vanilla `ApplicationCable::Connection`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Next, specify AnyCable subscription adapter for Action Cable:
 ```yml
 # config/cable.yml
 production:
-  adapter: any_cable
+  adapter: any_cable # or anycable
 ```
 
 and specify AnyCable WebSocket server URL:

--- a/lib/action_cable/subscription_adapter/anycable.rb
+++ b/lib/action_cable/subscription_adapter/anycable.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "any_cable"
+
+module ActionCable
+  module SubscriptionAdapter
+    # Aliasing adapter
+    Anycable = AnyCable
+  end
+end

--- a/lib/anycable/rails.rb
+++ b/lib/anycable/rails.rb
@@ -8,6 +8,12 @@ module AnyCable
   # Rails handler for AnyCable
   module Rails
     require "anycable/rails/railtie"
+
+    ADAPTER_ALIASES = %w[any_cable anycable].freeze
+
+    def self.compatible_adapter?(adapter)
+      ADAPTER_ALIASES.include?(adapter)
+    end
   end
 end
 

--- a/spec/integrations/subscription_adapter_spec.rb
+++ b/spec/integrations/subscription_adapter_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "subscription adapter" do
+  subject(:adapter) { ActionCable.server.config.pubsub_adapter }
+
+  specify { expect(adapter).to eq(ActionCable::SubscriptionAdapter::AnyCable) }
+
+  context "with alias" do
+    let(:config) { ActionCable.server.config.cable }
+
+    around do |ex|
+      old_adapter = config[:adapter]
+      config[:adapter] = "anycable"
+      ex.run
+      config[:adapter] = old_adapter
+    end
+
+    specify { expect(adapter).to eq(ActionCable::SubscriptionAdapter::AnyCable) }
+  end
+end


### PR DESCRIPTION
Issued in https://github.com/anycable/anycable-rails/issues/74#issuecomment-459902106

Do you still want to see the warning message? 