### PR TITLE
Fix compatibility to not conflict with the channel patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master
 
+- Fix Compatibility bug when using with AnyCable. ([@palkan][])
+
+  Compatibility patching (with `prepend` + `super`) conflicted with
+  the `ActionCable::Channel::Base` patching in the core functionality (which uses `alias`).
+
+  See [#95](https://github.com/anycable/anycable-rails/issues/95).
+
 ## 0.6.3 (2019-03-26)
 
 - Fix connection factory reloading for development sake. ([@sponomarev][])

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
+RSpec::Core::RakeTask.new(:spec)
+
 desc "Run compatibility specs"
 RSpec::Core::RakeTask.new("spec:compatibility") do |task|
   task.pattern = "spec/**/*_compatibility.rb"

--- a/lib/anycable/rails/actioncable/channel.rb
+++ b/lib/anycable/rails/actioncable/channel.rb
@@ -9,6 +9,9 @@ module ActionCable
 
       public :handle_subscribe, :subscription_rejected?
 
+      # Action Cable calls this method from inside the Subscriptions#add
+      # method, which we use to initialize the channel instance.
+      # We don't want to invoke `subscribed` callbacks every time we do that.
       def subscribe_to_channel
         # noop
       end

--- a/lib/anycable/rails/compatibility.rb
+++ b/lib/anycable/rails/compatibility.rb
@@ -18,7 +18,9 @@ module AnyCable
         super
       end
 
-      %w[subscribe_to_channel perform_action].each do |mid|
+      # Do not prepend `subscribe_to_channel` 'cause we make it no-op
+      # when AnyCable is running (see anycable/rails/actioncable/channel.rb)
+      %w[run_callbacks perform_action].each do |mid|
         module_eval <<~CODE, __FILE__, __LINE__ + 1
           def #{mid}(*)
             __anycable_check_ivars__ { super }

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -9,6 +9,7 @@ require "active_record/railtie"
 Bundler.require(*Rails.groups)
 
 require "anycable-rails"
+require "anycable/rails/compatibility"
 
 module Dummy
   class Application < Rails::Application


### PR DESCRIPTION
Prepending `subscribe_to_channel` in Compatibility results
in calling no-op implementation in AnyCable.

Patch `run_callbacks` instead to track ivars in channels.

Fixes #95.

