### PR TITLE
Make AnyCable patches compatible with Action Cable testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Make AnyCable patches compatible with Action Cable testing. ([@palkan][])
+
 - Do not add localhost `redis_url` to `anycable.yml` when Docker development method is chosen in `anycable:setup`. ([@palkan][])
 
 ## 1.0.0.rc2 (2020-06-16)

--- a/anycable-rails.gemspec
+++ b/anycable-rails.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ammeter", "~> 1.1"
   spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", ">= 3.4"
+  spec.add_development_dependency "rspec-rails", ">= 4.0.0"
   spec.add_development_dependency "rubocop", ">= 0.80"
   spec.add_development_dependency "warden"
 end

--- a/gemfiles/railsmaster.gemfile
+++ b/gemfiles/railsmaster.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gem "anycable", github: "anycable/anycable"
 
 gem "rails", github: "rails/rails"
-gem "rspec-rails", "~> 3.8.0"
+gem "rspec-rails", "~> 4.0.0"
 gem "sqlite3", "~> 1.4"
 
 gemspec path: ".."

--- a/lib/anycable/rails/actioncable/connection.rb
+++ b/lib/anycable/rails/actioncable/connection.rb
@@ -21,6 +21,8 @@ module ActionCable
 
       attr_reader :socket
 
+      alias anycable_socket socket
+
       delegate :env, :session, to: :request
 
       class << self

--- a/lib/anycable/rails/actioncable/connection/persistent_session.rb
+++ b/lib/anycable/rails/actioncable/connection/persistent_session.rb
@@ -28,3 +28,7 @@ module ActionCable
     end
   end
 end
+
+::ActionCable::Connection::Base.prepend(
+  ::ActionCable::Connection::PersistentSession
+)

--- a/lib/anycable/rails/actioncable/testing.rb
+++ b/lib/anycable/rails/actioncable/testing.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# This file contains patches to Action Cable testing modules
+
+# Trigger autoload (if constant is defined)
+begin
+  ActionCable::Channel::TestCase # rubocop:disable Lint/Void
+  ActionCable::Connection::TestCase # rubocop:disable Lint/Void
+rescue NameError
+  return
+end
+
+ActionCable::Channel::ChannelStub.prepend(Module.new do
+  def subscribe_to_channel
+    # allocate @streams
+    streams
+    handle_subscribe
+  end
+end)
+
+ActionCable::Channel::ConnectionStub.prepend(Module.new do
+  def socket
+    @socket ||= AnyCable::Socket.new(env: {})
+  end
+end)
+
+ActionCable::Connection::TestConnection.prepend(Module.new do
+  def initialize(request)
+    @request = request
+    @cached_ids = {}
+    super
+  end
+end)

--- a/lib/anycable/rails/actioncable/testing.rb
+++ b/lib/anycable/rails/actioncable/testing.rb
@@ -22,6 +22,8 @@ ActionCable::Channel::ConnectionStub.prepend(Module.new do
   def socket
     @socket ||= AnyCable::Socket.new(env: {})
   end
+
+  alias_method :anycable_socket, :socket
 end)
 
 ActionCable::Connection::TestConnection.prepend(Module.new do

--- a/lib/anycable/rails/channel_state.rb
+++ b/lib/anycable/rails/channel_state.rb
@@ -5,18 +5,16 @@ module AnyCable
     module ChannelState
       module ClassMethods
         def state_attr_accessor(*names)
-          return attr_accessor(*names) unless AnyCable::Rails.enabled?
-
           names.each do |name|
             channel_state_attributes << name
             class_eval <<~RUBY, __FILE__, __LINE__ + 1
               def #{name}
                 return @#{name} if instance_variable_defined?(:@#{name})
-                @#{name} = AnyCable::Rails.deserialize(connection.socket.istate["#{name}"], json: true)
+                @#{name} = AnyCable::Rails.deserialize(connection.socket.istate["#{name}"], json: true) if connection.anycable_socket
               end
 
               def #{name}=(val)
-                connection.socket.istate["#{name}"] = AnyCable::Rails.serialize(val, json: true)
+                connection.socket.istate["#{name}"] = AnyCable::Rails.serialize(val, json: true) if connection.anycable_socket
                 instance_variable_set(:@#{name}, val)
               end
             RUBY

--- a/lib/anycable/rails/railtie.rb
+++ b/lib/anycable/rails/railtie.rb
@@ -43,20 +43,24 @@ module AnyCable
 
       initializer "anycable.connection_factory", after: "action_cable.set_configs" do |app|
         ActiveSupport.on_load(:action_cable) do
+          app.config.to_prepare do
+            AnyCable.connection_factory = ActionCable.server.config.connection_class.call
+          end
+
           if AnyCable::Rails.enabled?
             require "anycable/rails/actioncable/connection"
-
             if AnyCable.config.persistent_session_enabled
               require "anycable/rails/actioncable/connection/persistent_session"
-              ::ActionCable::Connection::Base.prepend(
-                ::ActionCable::Connection::PersistentSession
-              )
-            end
-
-            app.config.to_prepare do
-              AnyCable.connection_factory = ActionCable.server.config.connection_class.call
             end
           end
+        end
+      end
+
+      initializer "anycable.testing" do |app|
+        next unless ::Rails.env.test?
+
+        ActiveSupport.on_load(:action_cable) do
+          require "anycable/rails/actioncable/testing"
         end
       end
     end

--- a/lib/anycable/rails/railtie.rb
+++ b/lib/anycable/rails/railtie.rb
@@ -43,6 +43,10 @@ module AnyCable
 
       initializer "anycable.connection_factory", after: "action_cable.set_configs" do |app|
         ActiveSupport.on_load(:action_cable) do
+          # Add AnyCable patch method stub (we use it in ChannelState to distinguish between Action Cable and AnyCable)
+          # NOTE: Method could be already defined if patch was loaded manually
+          ActionCable::Connection::Base.attr_reader(:anycable_socket) unless ActionCable::Connection::Base.method_defined?(:anycable_socket)
+
           app.config.to_prepare do
             AnyCable.connection_factory = ActionCable.server.config.connection_class.call
           end

--- a/spec/dummy/app/channels/application_cable/connection.rb
+++ b/spec/dummy/app/channels/application_cable/connection.rb
@@ -35,7 +35,7 @@ module ApplicationCable
 
       token = session[:token] || request.params[:token]
 
-      User.find_by(name: username, secret: token)
+      User.find_by!(name: username, secret: token)
     end
   end
 end

--- a/spec/integrations/action_cable_testing_spec.rb
+++ b/spec/integrations/action_cable_testing_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+return unless defined?(ActionCable::Channel::TestCase)
+
+describe "action cable testing compatibility", type: :channel do
+  extend(Module.new do
+    def channel_class
+      TestChannel
+    end
+  end)
+
+  let(:user) { User.create!(name: "max", secret: "123") }
+
+  context "channel tests" do
+    before { stub_connection current_user: user }
+
+    specify "subscription" do
+      subscribe
+      expect(subscription).to be_confirmed
+      expect(subscription).to have_stream_from("test")
+    end
+
+    specify "rejection" do
+      user.update!(secret: "312")
+      subscribe
+      expect(subscription).to be_rejected
+    end
+
+    specify "perform" do
+      subscribe
+
+      perform :itick
+
+      expect(transmissions.last).to eq("result" => 1)
+
+      perform :itick
+
+      expect(transmissions.last).to eq("result" => 2)
+    end
+  end
+
+  context "connection tests" do
+    extend(Module.new do
+      def connection_class
+        ApplicationCable::Connection
+      end
+    end)
+
+    specify "connect" do
+      connect "/cable?token=123", session: {username: user.name}
+
+      expect(connection.current_user).to eq user
+    end
+
+    specify "reject connection" do
+      expect { connect }.to have_rejected_connection
+    end
+
+    specify "disconnect" do
+      connect "/cable?token=123", session: {username: user.name}
+
+      disconnect
+
+      expect(ApplicationCable::Connection.events_log.last.fetch(:data)).to eq(name: "max", url: "http://test.host/cable?token=123")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require "base_spec_helper"
 
 require File.expand_path("spec/dummy/config/environment", PROJECT_ROOT)
 
+require "rspec/rails"
+
 Rails.application.eager_load!
 
 # This code is called from the server callback in Railtie


### PR DESCRIPTION
### What is the purpose of this pull request?

Make AnyCable compatible with Action Cable testing. That's only need when we want to run system tests with AnyCable. Otherwise using `test` adapter works fine.

### What changes did you make? (overview)

Added patches to testing stub modules.

### Is there anything you'd like reviewers to focus on?


### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
