### PR TITLE
Support command callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add support and backport for Connection command callbacks. ([@palkan][])
+
 ## 1.3.3 (2022-04-20)
 
 - Added `sid` (unique connection identifier) field to the `welcome` message if present. ([@palkan][])

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -17,10 +17,13 @@ Streaming | ✅
 Broadcasting | ✅
 Periodical timers | 🚫
 Disconnect remote clients | ✅
+Command callbacks | ✅ \*\*\*
 
 \* See [restoring state objects](../architecture.md#restoring-state-objects) for more information on how identifiers work.
 
 \*\* See [channel state](./channels_state.md) for more information on subscription instance variables support.
+
+\*\*\* AnyCable (via `anycable-rails`) also supports [command callbacks](https://github.com/rails/rails/pull/44696) (`before_command`, `after_command`, `around_command`) for older Rails versions (event when not using AnyCable).
 
 ## Runtime checks
 

--- a/lib/anycable/rails/connection.rb
+++ b/lib/anycable/rails/connection.rb
@@ -110,22 +110,24 @@ module AnyCable
       end
 
       def handle_channel_command(identifier, command, data)
-        # We cannot use subscriptions#execute_command here,
-        # since we MUST return true of false, depending on the status
-        # of execution
-        channel = conn.subscriptions.fetch(identifier)
-        case command
-        when "subscribe"
-          channel.handle_subscribe
-          !channel.rejected?
-        when "unsubscribe"
-          conn.subscriptions.remove_subscription(channel)
-          true
-        when "message"
-          channel.perform_action ActiveSupport::JSON.decode(data)
-          true
-        else
-          false
+        conn.run_callbacks :command do
+          # We cannot use subscriptions#execute_command here,
+          # since we MUST return true of false, depending on the status
+          # of execution
+          channel = conn.subscriptions.fetch(identifier)
+          case command
+          when "subscribe"
+            channel.handle_subscribe
+            !channel.rejected?
+          when "unsubscribe"
+            conn.subscriptions.remove_subscription(channel)
+            true
+          when "message"
+            channel.perform_action ActiveSupport::JSON.decode(data)
+            true
+          else
+            false
+          end
         end
       # Support rescue_from
       # https://github.com/rails/rails/commit/d2571e560c62116f60429c933d0c41a0e249b58b

--- a/spec/dummy/app/channels/application_cable/connection.rb
+++ b/spec/dummy/app/channels/application_cable/connection.rb
@@ -22,6 +22,8 @@ module ApplicationCable
 
     state_attr_accessor :token
 
+    around_command :log_command_execution
+
     def connect
       self.current_user = verify_user
       self.url = request.url if current_user
@@ -33,6 +35,12 @@ module ApplicationCable
     end
 
     private
+
+    def log_command_execution
+      start = Time.now
+      yield
+      self.class.log_event("command", time: Time.now - start)
+    end
 
     def verify_user
       return env["warden"]&.user if env["warden"]&.user

--- a/spec/integrations/action_cable_testing_spec.rb
+++ b/spec/integrations/action_cable_testing_spec.rb
@@ -65,5 +65,19 @@ describe "action cable testing compatibility", type: :channel do
 
       expect(ApplicationCable::Connection.events_log.last.fetch(:data)).to eq(name: "max", url: "http://test.host/cable?token=123")
     end
+
+    specify "callbacks" do
+      connect "/cable?token=123", session: {username: user.name}
+
+      connection.handle_channel_command(
+        {
+          "identifier" => {channel: "ChatChannel"}.to_json,
+          "command" => "subscribe"
+        }
+      )
+
+      expect(connection.transmissions.last["type"]).to eq("confirm_subscription")
+      expect(ApplicationCable::Connection.events_log.last[:source]).to eq "command"
+    end
   end
 end

--- a/spec/integrations/rpc/perform_spec.rb
+++ b/spec/integrations/rpc/perform_spec.rb
@@ -51,6 +51,16 @@ describe "client messages" do
       end
     end
 
+    context "with arround_command" do
+      let(:log) { ApplicationCable::Connection.events_log }
+
+      it "executes command callbacks" do
+        expect { subject }.to change { log.size }.by(1)
+
+        expect(log.last[:source]).to eq "command"
+      end
+    end
+
     describe "#stop_stream_from" do
       let(:data) { {action: "unfollow_all"} }
 


### PR DESCRIPTION
Add support for [command callbacks](https://github.com/rails/rails/pull/44696) and backport them for older Rails.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
