### PR TITLE
Update download_generator.rb to make it work

### DIFF
--- a/lib/generators/anycable/download/download_generator.rb
+++ b/lib/generators/anycable/download/download_generator.rb
@@ -44,12 +44,12 @@ module AnyCableRailsGenerators
     end
 
     def legacy_release_url(version)
-      "https://github.com/anycable/anycable-go/releases/download/#{version}/" \
+      "https://github.com/anycable/anycable-go/releases/download/v#{version}/" \
         "anycable-go-v#{version}-#{os_name}-#{cpu_name}"
     end
 
     def new_release_url(version)
-      "https://github.com/anycable/anycable-go/releases/download/#{version}/" \
+      "https://github.com/anycable/anycable-go/releases/download/v#{version}/" \
         "anycable-go-#{os_name}-#{cpu_name}"
     end
 


### PR DESCRIPTION
```ruby
$ ./bin/rails g anycable:download --version=1.4.0 --bin-path=./bin/dist
rails: no version found in package 1.4.0

$ ./bin/rails g anycable:download --version=v1.4.0 --bin-path=./bin/dist 
rails: no version found in package v1.4.0
```

Right now only `latest` working for generator
