### PR TITLE
Auto batching for broadcasts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,8 @@ jobs:
             gemfile: "railsmaster"
           - ruby: "2.7"
             gemfile: "rails60"
+          - ruby: "3.2"
+            gemfile: "anycablemaster"
     steps:
     - uses: actions/checkout@v2
     - name: Install system deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `batch_broadcasts` option to automatically batch broadcasts for code wrapped in Rails executor. ([@palkan][])
+
 ## 1.4.1 (2023-09-27)
 
 - Fix compatibility with Rails 7.1. ([@palkan][])

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -91,6 +91,12 @@ production:
 
 Or you can use the environment variables (or anything else supported by [anyway_config](https://github.com/palkan/anyway_config)).
 
+### Batching broadcasts automatically
+
+AnyCable supports publishing [broadcast messages in batches](../ruby/broadcast_adapters.md#batching) (to reduce the number of round-trips and ensure delivery order). You can enable automatic batching of broadcasts by setting `ANYCABLE_BROADCAST_BATCHING=true` (or `broadcast_batching: true` in the config file).
+
+Auto-batching uses [Rails executor](https://guides.rubyonrails.org/threading_and_code_execution.html#executor) under the hood, so broadcasts are aggregated within Rails _units of work_, such as HTTP requests, background jobs, etc.
+
 ### Server installation
 
 You can install AnyCable-Go server using one of the [multiple ways](../anycable-go/getting_started.md#installation).

--- a/gemfiles/anycablemaster.gemfile
+++ b/gemfiles/anycablemaster.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", ">= 7.1"
+gem "rspec-rails"
+gem "anycable", git: "https://github.com/anycable/anycable.git", branch: "master"
+gem "sqlite3", "~> 1.4"
+
+gemspec path: "..", name: "anycable-rails"

--- a/lib/anycable/rails/config.rb
+++ b/lib/anycable/rails/config.rb
@@ -10,10 +10,12 @@ require "anyway/rails"
 # - `persistent_session_enabled` (defaults to false) — whether to store session changes in the connection state
 # - `embedded` (defaults to false) — whether to run RPC server inside a Rails server process
 # - `http_rpc_mount_path` (default to nil) — path to mount HTTP RPC server
+# - `batch_broadcasts` (defaults to false) — whether to batch broadcasts automatically for code wrapped with Rails executor
 AnyCable::Config.attr_config(
   access_logs_disabled: true,
   persistent_session_enabled: false,
   embedded: false,
-  http_rpc_mount_path: nil
+  http_rpc_mount_path: nil,
+  batch_broadcasts: false
 )
 AnyCable::Config.ignore_options :access_logs_disabled, :persistent_session_enabled

--- a/lib/anycable/rails/railtie.rb
+++ b/lib/anycable/rails/railtie.rb
@@ -59,6 +59,15 @@ module AnyCable
             ::Rails.error.report(ex, handled: false, context: {method: method.to_sym, payload: message})
           end
         end
+
+        if AnyCable.config.batch_broadcasts?
+          if AnyCable.broadcast_adapter.respond_to?(:start_batching)
+            app.executor.to_run { AnyCable.broadcast_adapter.start_batching }
+            app.executor.to_complete { AnyCable.broadcast_adapter.finish_batching }
+          else
+            warn "[AnyCable] Auto-batching is enabled for broadcasts but your anycable version doesn't support it. Please, upgrade"
+          end
+        end
       end
 
       initializer "anycable.connection_factory", after: "action_cable.set_configs" do |app|

--- a/spec/dummy/app/controllers/broadcasts_controller.rb
+++ b/spec/dummy/app/controllers/broadcasts_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class BroadcastsController < ApplicationController
+  around_action :maybe_disable_auto_batching
+
+  def create
+    params[:count].to_i.times do |num|
+      ActionCable.server.broadcast "test", {count: num + 1}
+    end
+
+    head :created
+  end
+
+  private
+
+  def maybe_disable_auto_batching(&block)
+    return yield unless params[:disable_auto_batching]
+    AnyCable.broadcast_adapter.batching(false, &block)
+  end
+end

--- a/spec/dummy/config/anycable.yml
+++ b/spec/dummy/config/anycable.yml
@@ -4,3 +4,4 @@ test:
   access_logs_disabled: false
   persistent_session_enabled: true
   http_rpc_mount_path: "/_anycable"
+  batch_broadcasts: true

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,4 +2,5 @@
 
 Rails.application.routes.draw do
   resources :sessions, only: [:create]
+  resources :broadcasts, only: [:create]
 end

--- a/spec/integrations/auto_batching_spec.rb
+++ b/spec/integrations/auto_batching_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_controller/test_case"
+
+describe "auto-batching", skip: !AnyCable.broadcast_adapter.respond_to?(:start_batching) do
+  include ActionDispatch::Integration::Runner
+  include ActionDispatch::IntegrationTest::Behavior
+
+  # Delegates to `Rails.application`.
+  def app
+    ::Rails.application
+  end
+
+  before { allow(AnyCable.broadcast_adapter).to receive(:raw_broadcast) }
+
+  it "delivers broadcasts in a single batch" do
+    post "/broadcasts", params: {count: 3}
+    expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).once
+  end
+
+  context "when auto_batching disabled" do
+    it "delivers broadcast individually" do
+      post "/broadcasts", params: {count: 4, disable_auto_batching: true}
+      expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).exactly(4).times
+    end
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a follow-up for https://github.com/anycable/anycable/pull/216.

Batching broadcasts automatically in a Rails app may be useful (especially for web requests).

### What changes did you make? (overview)

- [x] Added `Rails.application.executor` hooks to manage batching
- [x] Configured CI to run tests against anycable master

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
