### PR TITLE
Broadcast to others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add support for broadcast options (e.g., `exclude_socket`). ([@palkan][])
+
 - Add `batch_broadcasts` option to automatically batch broadcasts for code wrapped in Rails executor. ([@palkan][])
 
 ## 1.4.1 (2023-09-27)

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ if File.exist?(local_gemfile)
 else
   gem 'actioncable', '~> 7.0'
   gem 'activerecord'
+  gem 'activejob'
 end
 
 gem 'sqlite3', '~> 1.3'

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -206,6 +206,19 @@ AnyCable::Rails.broadcasting_to_others do
 end
 ```
 
+You can also pass socket ID explicitly (if obtained from another source):
+
+```ruby
+AnyCable::Rails.broadcasting_to_others(socket_id: my_socket_id) do
+ # ...
+end
+
+# or
+ActionCable.server.broadcast stream, data, exclude_socket: my_socket_id
+````
+
+**IMPORTANT:** AnyCable Rails automatically pass the current socket ID to Active Job, so you can use `broadcast ..., to_others: true` in your background jobs without any additional configuration.
+
 ## Development and test
 
 AnyCable is [compatible](compatibility.md) with the original Action Cable implementation; thus you can continue using Action Cable for development and tests.

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "actioncable", "~> 5.1"
 gem "activerecord"
+gem "activejob"
 gem "rspec-rails", "~> 4.0.0"
 gem "sqlite3", "~> 1.3"
 

--- a/gemfiles/rails6.gemfile
+++ b/gemfiles/rails6.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "actioncable", "~> 6.0"
 gem "activerecord"
+gem "activejob"
 gem "rspec-rails", "~> 4.0.0"
 gem "sqlite3", "~> 1.4"
 

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "actioncable", "~> 6.0.0"
 gem "activerecord"
+gem "activejob"
 gem "rspec-rails", "~> 4.0.0"
 gem "sqlite3", "~> 1.4"
 

--- a/gemfiles/rails7.gemfile
+++ b/gemfiles/rails7.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "actioncable", "~> 7.0"
 gem "activerecord"
+gem "activejob"
 gem "rspec-rails", "~> 4.0.0"
 gem "sqlite3", "~> 1.4"
 

--- a/lib/action_cable/subscription_adapter/any_cable.rb
+++ b/lib/action_cable/subscription_adapter/any_cable.rb
@@ -18,8 +18,11 @@ module ActionCable
       def initialize(*)
       end
 
-      def broadcast(channel, payload)
-        ::AnyCable.broadcast(channel, payload)
+      def broadcast(channel, payload, **options)
+        options.merge!(::AnyCable::Rails.current_broadcast_options || {})
+        to_others = options.delete(:to_others)
+        options[:exclude_socket] ||= ::AnyCable::Rails.current_socket_id if to_others
+        ::AnyCable.broadcast(channel, payload, **options.compact)
       end
 
       def subscribe(*)

--- a/lib/anycable/rails.rb
+++ b/lib/anycable/rails.rb
@@ -43,8 +43,12 @@ module AnyCable
         self.current_broadcast_options = old_options
       end
 
-      def broadcasting_to_others(&block)
-        with_broadcast_options(to_others: true, &block)
+      def broadcasting_to_others(socket_id: nil, &block)
+        if socket_id
+          with_socket_id(socket_id) { with_broadcast_options(to_others: true, &block) }
+        else
+          with_broadcast_options(to_others: true, &block)
+        end
       end
 
       # Serialize connection/channel state variable to string

--- a/lib/anycable/rails/action_cable_ext/broadcast_options.rb
+++ b/lib/anycable/rails/action_cable_ext/broadcast_options.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "action_cable"
+
+ActionCable::Server::Base.prepend(Module.new do
+  def broadcast(channel, payload, **options)
+    return super if options.empty?
+
+    AnyCable::Rails.with_broadcast_options(**options) do
+      super(channel, payload)
+    end
+  end
+end)
+
+ActionCable::Channel::Base.singleton_class.prepend(Module.new do
+  def broadcast_to(target, payload, **options)
+    return super if options.empty?
+
+    AnyCable::Rails.with_broadcast_options(**options) do
+      super(target, payload)
+    end
+  end
+end)

--- a/lib/anycable/rails/config.rb
+++ b/lib/anycable/rails/config.rb
@@ -16,6 +16,7 @@ AnyCable::Config.attr_config(
   persistent_session_enabled: false,
   embedded: false,
   http_rpc_mount_path: nil,
-  batch_broadcasts: false
+  batch_broadcasts: false,
+  socket_id_header: "X-Socket-ID"
 )
 AnyCable::Config.ignore_options :access_logs_disabled, :persistent_session_enabled

--- a/lib/anycable/rails/middlewares/executor.rb
+++ b/lib/anycable/rails/middlewares/executor.rb
@@ -13,16 +13,16 @@ module AnyCable
         end
 
         def call(method, message, metadata)
+          sid = metadata["sid"]
+
           if ::Rails.respond_to?(:error)
             executor.wrap do
-              sid = metadata["sid"]
-
               ::Rails.error.record(context: {method: method, payload: message.to_h, sid: sid}) do
-                yield
+                Rails.with_socket_id(sid) { yield }
               end
             end
           else
-            executor.wrap { yield }
+            executor.wrap { Rails.with_socket_id(sid) { yield } }
           end
         end
       end

--- a/lib/anycable/rails/railtie.rb
+++ b/lib/anycable/rails/railtie.rb
@@ -3,6 +3,7 @@
 require "anycable/rails/action_cable_ext/connection"
 require "anycable/rails/action_cable_ext/channel"
 require "anycable/rails/action_cable_ext/remote_connections"
+require "anycable/rails/action_cable_ext/broadcast_options"
 
 require "anycable/rails/channel_state"
 require "anycable/rails/connection_factory"
@@ -67,6 +68,13 @@ module AnyCable
           else
             warn "[AnyCable] Auto-batching is enabled for broadcasts but your anycable version doesn't support it. Please, upgrade"
           end
+        end
+      end
+
+      initializer "anycable.socket_id_tracking" do
+        ActiveSupport.on_load(:action_controller) do
+          require "anycable/rails/socket_id_tracking"
+          include AnyCable::Rails::SocketIdTracking
         end
       end
 

--- a/lib/anycable/rails/railtie.rb
+++ b/lib/anycable/rails/railtie.rb
@@ -74,7 +74,12 @@ module AnyCable
       initializer "anycable.socket_id_tracking" do
         ActiveSupport.on_load(:action_controller) do
           require "anycable/rails/socket_id_tracking"
-          include AnyCable::Rails::SocketIdTracking
+          include AnyCable::Rails::SocketIdTrackingController
+        end
+
+        ActiveSupport.on_load(:active_job) do
+          require "anycable/rails/socket_id_tracking"
+          include AnyCable::Rails::SocketIdTrackingJob
         end
       end
 

--- a/lib/anycable/rails/socket_id_tracking.rb
+++ b/lib/anycable/rails/socket_id_tracking.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module AnyCable
+  module Rails
+    module SocketIdTracking
+      extend ActiveSupport::Concern
+
+      included do
+        around_action :anycable_tracking_socket_id
+      end
+
+      private
+
+      def anycable_tracking_socket_id(&block)
+        Rails.with_socket_id(request.headers[AnyCable.config.socket_id_header], &block)
+      end
+    end
+  end
+end

--- a/lib/anycable/rails/socket_id_tracking.rb
+++ b/lib/anycable/rails/socket_id_tracking.rb
@@ -2,7 +2,7 @@
 
 module AnyCable
   module Rails
-    module SocketIdTracking
+    module SocketIdTrackingController
       extend ActiveSupport::Concern
 
       included do
@@ -13,6 +13,29 @@ module AnyCable
 
       def anycable_tracking_socket_id(&block)
         Rails.with_socket_id(request.headers[AnyCable.config.socket_id_header], &block)
+      end
+    end
+
+    module SocketIdTrackingJob
+      extend ActiveSupport::Concern
+
+      attr_accessor :cable_socket_id
+
+      def serialize
+        return super unless Rails.current_socket_id
+
+        super.merge("cable_socket_id" => Rails.current_socket_id)
+      end
+
+      def deserialize(job_data)
+        super
+        self.cable_socket_id = job_data["cable_socket_id"]
+      end
+
+      included do
+        around_perform do |job, block|
+          Rails.with_socket_id(job.cable_socket_id, &block)
+        end
       end
     end
   end

--- a/spec/dummy/app/controllers/broadcasts_controller.rb
+++ b/spec/dummy/app/controllers/broadcasts_controller.rb
@@ -4,8 +4,9 @@ class BroadcastsController < ApplicationController
   around_action :maybe_disable_auto_batching
 
   def create
+    options = params[:to_others] ? {to_others: true} : {}
     params[:count].to_i.times do |num|
-      ActionCable.server.broadcast "test", {count: num + 1}
+      ActionCable.server.broadcast "test", {count: num + 1}, **options
     end
 
     head :created

--- a/spec/dummy/app/jobs/broadcast_job.rb
+++ b/spec/dummy/app/jobs/broadcast_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BroadcastJob < ActiveJob::Base
+  def perform(stream, data, to_others = false)
+    ActionCable.server.broadcast(stream, data, to_others: to_others)
+  end
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -3,6 +3,7 @@
 require_relative "boot"
 require "action_controller/railtie"
 require "action_cable/engine"
+require "active_job/railtie"
 require "global_id/railtie"
 require "active_record/railtie"
 

--- a/spec/integrations/broadcast_to_others_spec.rb
+++ b/spec/integrations/broadcast_to_others_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_controller/test_case"
+
+supported = AnyCable.method(:broadcast).arity != 2
+
+describe "broadcast to others", skip: !supported do
+  include ActionDispatch::Integration::Runner
+  include ActionDispatch::IntegrationTest::Behavior
+
+  # Delegates to `Rails.application`.
+  def app
+    ::Rails.application
+  end
+
+  before { allow(AnyCable.broadcast_adapter).to receive(:raw_broadcast) }
+
+  it "adds exclude_socket meta if X-Socket-ID header is provided" do
+    post "/broadcasts", params: {count: 1, to_others: true, disable_auto_batching: true}, headers: {"X-Socket-ID" => "134"}
+
+    expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).once
+    expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).with(
+      {
+        stream: "test",
+        data: {count: 1}.to_json,
+        meta: {exclude_socket: "134"}
+      }.to_json
+    )
+  end
+
+  it "doesn't add meta if header is missing" do
+    post "/broadcasts", params: {count: 1, to_others: true, disable_auto_batching: true}
+
+    expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).once
+    expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).with(
+      {
+        stream: "test",
+        data: {count: 1}.to_json
+      }.to_json
+    )
+  end
+
+  context "with custom header" do
+    around do |example|
+      was_value = AnyCable.config.socket_id_header
+      AnyCable.config.socket_id_header = "X-My-Socket-ID"
+      example.run
+    ensure
+      AnyCable.config.socket_id_header = was_value
+    end
+
+    specify do
+      post "/broadcasts", params: {count: 1, to_others: true, disable_auto_batching: true}, headers: {"X-My-Socket-ID" => "134"}
+
+      expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).once
+      expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).with(
+        {
+          stream: "test",
+          data: {count: 1}.to_json,
+          meta: {exclude_socket: "134"}
+        }.to_json
+      )
+    end
+  end
+end

--- a/spec/lib/anycable/rails/channel_spec.rb
+++ b/spec/lib/anycable/rails/channel_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+supported = AnyCable.method(:broadcast).arity != 2
+
+describe ActionCable::Channel::Base, skip: !supported do
+  before { allow(AnyCable.broadcast_adapter).to receive(:raw_broadcast) }
+
+  describe ".broadcast_to" do
+    context "with to_others: true" do
+      it "adds exclude_socket meta if current_socket_id is defined" do
+        AnyCable::Rails.with_socket_id("456") do
+          TestChannel.broadcast_to("test", {foo: "bar"}, to_others: true)
+        end
+
+        expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).once
+        expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).with(
+          {
+            stream: "test:test",
+            data: {foo: "bar"}.to_json,
+            meta: {exclude_socket: "456"}
+          }.to_json
+        )
+      end
+    end
+
+    context "when broadcasting_to_others is set" do
+      specify do
+        AnyCable::Rails.with_socket_id("456") do
+          AnyCable::Rails.broadcasting_to_others do
+            TestChannel.broadcast_to("test", {foo: "baz"})
+          end
+        end
+
+        expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).once
+        expect(AnyCable.broadcast_adapter).to have_received(:raw_broadcast).with(
+          {
+            stream: "test:test",
+            data: {foo: "baz"}.to_json,
+            meta: {exclude_socket: "456"}
+          }.to_json
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

This feature brings the ability to deliver broadcast events to everyone except the current session.

Based on https://github.com/anycable/anycable/pull/218 and https://github.com/anycable/anycable-go/pull/194

### What changes did you make? (overview)

- [x] Extended `Server#broadcast` and `Channel.broadcast_to` methods to accept broadcast options as their third argument
- [x] Added `AnyCable::Rails.broadcasting_to_other { }` method to set the option for the inner code block (in case broadcast is called indirectly, e.g., with Turbo Streams)
- [x] Added Action Controller extension to set the current socket id from request headers 
- [x] Added Active Job extensions to carry `current_socket_id` to jobs

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
