### PR TITLE
Fix broadcast logging in rails 7.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Add `batch_broadcasts` option to automatically batch broadcasts for code wrapped in Rails executor. ([@palkan][])
 
+- Fix broadcast logging in Rails 7.1. ([@iuri-gg][])
+
 ## 1.4.1 (2023-09-27)
 
 - Fix compatibility with Rails 7.1. ([@palkan][])

--- a/lib/anycable/rails/railtie.rb
+++ b/lib/anycable/rails/railtie.rb
@@ -31,8 +31,8 @@ module AnyCable
             console.level = ::Rails.logger.level if ::Rails.logger.respond_to?(:level)
 
             # Rails 7.1+
-            if defined?(ActiveSupport::BroadcastLogger)
-              AnyCable.logger = ActiveSupport::BroadcastLogger.new(AnyCable.logger, console)
+            if AnyCable.logger.respond_to?(:broadcast_to)
+              AnyCable.logger.broadcast_to(console)
             else
               AnyCable.logger.extend(ActiveSupport::Logger.broadcast(console))
             end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes:

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

-->

### What is the purpose of this pull request?
Fixes issue with Rails 7.1. [Previous fix](https://github.com/anycable/anycable-rails/commit/39de9ef5d35a4a5384cd1602d998c4de5604969e) sets `Anycable.logger` to an instance of `BroadcastLogger` with two loggers (`console` and previous instance of `BroadcastLogger`). This nested `BroadcastLogger` breaks with following error:
```
undefined method `current_tags' for nil:NilClass:
/Users/iuri/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actioncable-7.1.1/lib/action_cable/connection/tagged_logger_proxy.rb:25:in `tag'
/Users/iuri/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actioncable-7.1.1/lib/action_cable/connection/tagged_logger_proxy.rb:40:in `log'
/Users/iuri/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actioncable-7.1.1/lib/action_cable/connection/tagged_logger_proxy.rb:34:in `block (2 levels) in <class:TaggedLoggerProxy>'
/Users/iuri/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/anycable-rails-core-1.4.1/lib/anycable/rails/connection.rb:89:in `handle_open'
...
```

### What changes did you make? (overview)
[Use official `#broadcast_to` API](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#rails-logger-now-returns-an-activesupport-broadcastlogger-instance)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated documentation
