### PR TITLE
[DRAFT] Whispering backport for Action Cable

### DIFF
--- a/lib/anycable/rails/action_cable_ext/channel.rb
+++ b/lib/anycable/rails/action_cable_ext/channel.rb
@@ -24,6 +24,11 @@ ActionCable::Channel::Base.prepend(Module.new do
 
   def stream_from(broadcasting, _callback = nil, **opts)
     whispering = opts.delete(:whisper)
+    if whispering
+      self.class.state_attr_accessor(:whisper_stream) unless respond_to?(:whisper_stream)
+      self.whisper_stream = broadcasting
+    end
+
     return super unless anycabled?
 
     broadcasting = String(broadcasting)
@@ -48,6 +53,12 @@ ActionCable::Channel::Base.prepend(Module.new do
     return super unless anycabled?
 
     connection.anycable_socket.unsubscribe_from_all identifier
+  end
+
+  def whisper(payload)
+    return unless whisper_stream
+
+    broadcast_to whisper_stream, payload
   end
 
   private

--- a/lib/anycable/rails/action_cable_ext/channel.rb
+++ b/lib/anycable/rails/action_cable_ext/channel.rb
@@ -55,12 +55,6 @@ ActionCable::Channel::Base.prepend(Module.new do
     connection.anycable_socket.unsubscribe_from_all identifier
   end
 
-  def whisper(payload)
-    return unless whisper_stream
-
-    broadcast_to whisper_stream, payload
-  end
-
   private
 
   def anycabled?

--- a/lib/anycable/rails/action_cable_ext/whisper_stream.rb
+++ b/lib/anycable/rails/action_cable_ext/whisper_stream.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "action_cable"
+
+ActionCable::Connection::Subscriptions.prepend(Module.new do
+  def execute_command(data)
+    return whisper(data) if data["command"] == "whisper"
+
+    super
+  end
+
+  def whisper(data)
+    find(data).whisper(ActiveSupport::JSON.decode(data["data"]))
+  end
+end)

--- a/lib/anycable/rails/action_cable_ext/whisper_stream.rb
+++ b/lib/anycable/rails/action_cable_ext/whisper_stream.rb
@@ -10,6 +10,9 @@ ActionCable::Connection::Subscriptions.prepend(Module.new do
   end
 
   def whisper(data)
-    find(data).whisper(ActiveSupport::JSON.decode(data["data"]))
+    subscription = find(data)
+    if subscription.whisper_stream
+      connection.anycable_socket.whisper data["identifier"], subscription.whisper_stream
+    end
   end
 end)

--- a/lib/anycable/rails/ext.rb
+++ b/lib/anycable/rails/ext.rb
@@ -5,6 +5,7 @@ module AnyCable
     module Ext
       autoload :JWT, "anycable/rails/ext/jwt"
       autoload :SignedStreams, "anycable/rails/ext/signed_streams"
+      autoload :WhisperStreams, "anycable/rails/ext/whisper_stream"
     end
   end
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

Add whispering backport for Action Cable

### Is there anything you'd like reviewers to focus on?
@palkan Hi! Could you please take a look at the MR? Did I understand the essence of the issue correctly?

That is, we want to have the following code in our Rails application:

```js
import consumer from "channels/consumer"

consumer.subscriptions.create("ChatChannel", {
  whisper(payload) {
    this.perform("whisper", payload);
  }
})
```

Which will trigger the execution of the predefined `#whisper` method from the channel?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation

Closes https://github.com/anycable/anycable-rails/issues/198