### PR TITLE
Improve `AnyCable/PeriodicalTimers` cop performance

### DIFF
--- a/lib/anycable/rails/rubocop/cops/anycable/periodical_timers.rb
+++ b/lib/anycable/rails/rubocop/cops/anycable/periodical_timers.rb
@@ -15,14 +15,9 @@ module RuboCop
       #
       class PeriodicalTimers < RuboCop::Cop::Base
         MSG = "Periodical Timers are not supported in AnyCable"
+        RESTRICT_ON_SEND = %i[periodically].freeze
 
-        def_node_matcher :calls_periodically?, <<-PATTERN
-          (send _ :periodically ...)
-        PATTERN
-
-        def on_send(node)
-          add_offense(node) if calls_periodically?(node)
-        end
+        alias_method :on_send, :add_offense
       end
     end
   end


### PR DESCRIPTION
Since we match any `periodically` method we can configure `RESTRICT_ON_SEND` to prevent unrelated `send` nodes from being dispatched.

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes:

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

-->

### Checklist

- [ ] I've added tests for this change **(not applicable)**
- [ ] I've added a Changelog entry  **(not applicable)**
- [ ] I've updated documentation  **(not applicable)**
 