### PR TITLE
Skip disconnect implementation when disabled

### DIFF
--- a/lib/anycable/rails/action_cable_ext/remote_connections.rb
+++ b/lib/anycable/rails/action_cable_ext/remote_connections.rb
@@ -6,7 +6,7 @@ ActionCable::RemoteConnections::RemoteConnection.include(AnyCable::Rails::Connec
 ActionCable::RemoteConnections::RemoteConnection.prepend(Module.new do
   def disconnect(reconnect: true)
     # Legacy Action Cable functionality if case we're not fully migrated yet
-    super unless AnyCable::Rails.enabled?
+    return super unless AnyCable::Rails.enabled?
     ::AnyCable.broadcast_adapter.broadcast_command("disconnect", identifier: identifiers_json, reconnect: reconnect)
   end
 end)

--- a/spec/lib/anycable/rails/remote_connections_spec.rb
+++ b/spec/lib/anycable/rails/remote_connections_spec.rb
@@ -17,4 +17,21 @@ describe ActionCable::RemoteConnections do
         reconnect: true
       )
   end
+
+  context "when AnyCable is disabled" do
+    before do
+      @old = ActionCable.server.config.cable[:adapter]
+      ActionCable.server.config.cable[:adapter] = "test"
+    end
+
+    after do
+      ActionCable.server.config.cable[:adapter] = @old
+    end
+
+    it "doesn't call #broadcast_command" do
+      ActionCable.server.disconnect(current_user: user, url: "anycable.io/cable")
+
+      expect(AnyCable.broadcast_adapter).not_to have_received(:broadcast_command)
+    end
+  end
 end


### PR DESCRIPTION
Ensure the `[ActionCable::RemoteConnections::RemoteConnection]` monkey patch is only run when AnyCable is enabled by immediately `return`-ing the result our guard clause.

### What is the purpose of this pull request?

AnyCable's disconnect code is being run when Action Cable is using the `test` adapter. In our case this means our specs are handing while AnyCable tries to connect to a (non-existent) NATs server. From reading the code it seems the intention was to guard AnyCable's code behind an early return, this makes that so.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
