### PR TITLE
Ensure `bin/dist/anycable-go` has execution permission as part of `bin/anycable-go`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Ensure `bin/dist/anycable-go` has execution permission as part of `bin/anycable-go` ([@dmorgan-fa][])
+
 ## 1.6.0 (2025-03-18)
 
 - Update `anycable:download` generator to support v1.6+. ([@palkan][])

--- a/lib/generators/anycable/bin/templates/bin/anycable-go.tt
+++ b/lib/generators/anycable/bin/templates/bin/anycable-go.tt
@@ -10,6 +10,11 @@ if [ ! -f ./bin/dist/anycable-go ]; then
   ./bin/rails g anycable:download --version=$version --bin-path=./bin/dist
 fi
 
+if [ -x ./bin/dist/anycable-go ]; then
+  echo "Setting execution permission for AnyCable server"
+  chmod +x ./bin/dist/anycable-go
+fi
+
 curVersion=$(./bin/dist/anycable-go -v)
 
 if [[ "$version" != "latest" ]]; then

--- a/lib/generators/anycable/setup/templates/bin/anycable-go.tt
+++ b/lib/generators/anycable/setup/templates/bin/anycable-go.tt
@@ -10,6 +10,11 @@ if [ ! -f ./bin/dist/anycable-go ]; then
   ./bin/rails g anycable:download --version=$version --bin-path=./bin/dist
 fi
 
+if [ -x ./bin/dist/anycable-go ]; then
+  echo "Setting execution permission for AnyCable server"
+  chmod +x ./bin/dist/anycable-go
+fi
+
 curVersion=$(./bin/dist/anycable-go -v)
 
 if [[ "$version" != "latest" ]]; then


### PR DESCRIPTION
Someone on my team ran into an issue where even though the `bin/dist/anycable-go` binary had been downloaded by `bin/anycable-go`, the binary failed to have execution permission.

This resulted in `Permission denied` errors when running `bin/anycable-go`, and it wasn't immediately apparent for them to be able to debug the issue.

The download task does have an explicit step that sets the execution bit:
- https://github.com/anycable/anycable-rails/blob/e4dcb9312c5513458f71863182dc89021d794282/lib/generators/anycable/download/download_generator.rb#L77-L79

For _some_ reason this failed in their case, and it made things difficult to debug.

By having `bin/anycable-go` check for execution permission before calling the binary we can avoid this unexpected edge-case.

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated documentation
