### PR TITLE
Ignore ivar set by graphql-anycable during compatibility check

### DIFF
--- a/lib/anycable/rails/compatibility.rb
+++ b/lib/anycable/rails/compatibility.rb
@@ -9,6 +9,7 @@ module AnyCable
       @_streams
       @parameter_filter
       @whisper_stream
+      @__sid__
     ]
 
     ActionCable::Channel::Base.prepend(Module.new do


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix compatibility between `graphql-anycable` and `anycable/rails/compatibility` module.

#### Minimal steps to reproduce:

In development environment:

```ruby
# in Gemfile
gem "anycable-rails" # 1.6.1
gem "graphql-anycable" # 1.3.1
```

```ruby
# in config/application.rb
require "anycable/rails/compatibility"
```

Then configure GraphQL channel as per [official README](https://github.com/anycable/graphql-anycable?tab=readme-ov-file#usage).

In AnyCable WS logs it will show:

```
 WRN failed to handle incoming message [...] data="{\"id\":\"...\",\"type\":\"subscribe\",\"payload\":{\"variables\":{},\"operation...(133)" error="perform failed for {\"channel\":\"GraphqlChannel\",\"channelId\":\"...\"}, cause: Application error: Channel instance variables are not supported by AnyCable, but were set: @__sid__"
```

A similar error will be shown in AnyCable RPC logs as well.

### What changes did you make? (overview)

Ignore `@__sid__` instance variables, which is used internally by `Grahpql::Subscriptions::AnyCableSubscriptions` for connection management, when `AnyCable::Compatibility` runs.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation
