### PR TITLE
fix: cast the presence id to a string on leave, matching join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+- Cast the presence ID to a string on leave, matching join. ([@ashwin47][])
+
+  `#join_presence` already casts the ID via `#to_s`, but `#leave_presence` passed it through untouched, so a non-string `user_presence_id` (e.g. a numeric record id) raised `Invalid argument for string field 'id'` when building the presence response.
+
 ## 1.6.2 (2026-04-02)
 
 - Upgrade setup generator. ([@palkan][])
@@ -306,3 +310,4 @@ See [Changelog](https://github.com/anycable/anycable-rails/blob/0-6-stable/CHANG
 [@sponomarev]: https://github.com/sponomarev
 [@bibendi]: https://github.com/bibendi
 [@lHydra]: http://github.com/lHydra
+[@ashwin47]: https://github.com/ashwin47

--- a/lib/anycable/rails/channel/presence.rb
+++ b/lib/anycable/rails/channel/presence.rb
@@ -18,7 +18,7 @@ module AnyCable
         def leave_presence(id = user_presence_id)
           return unless anycabled?
 
-          connection.anycable_socket.presence_leave(id)
+          connection.anycable_socket.presence_leave(id.to_s)
         end
 
         private

--- a/spec/dummy/app/channels/test_channel.rb
+++ b/spec/dummy/app/channels/test_channel.rb
@@ -26,6 +26,19 @@ class TestChannel < ApplicationCable::Channel
     leave_presence current_user.name
   end
 
+  # `#user_presence_id` below returns a non-string (a numeric record id, as the
+  # docs recommend). Join/leave with no explicit id fall back to it, and the id
+  # must be cast before it reaches the string `id` field of the presence proto.
+  def follow_by_id
+    stream_from "all"
+
+    join_presence
+  end
+
+  def unfollow_by_id
+    leave_presence
+  end
+
   def nil_stream
     stream_from nil
   end
@@ -62,6 +75,8 @@ class TestChannel < ApplicationCable::Channel
   end
 
   private
+
+  def user_presence_id = current_user.id
 
   def unsubscribed_params
     {name: name}

--- a/spec/integrations/rpc/perform_spec.rb
+++ b/spec/integrations/rpc/perform_spec.rb
@@ -142,5 +142,28 @@ describe "client messages" do
         expect(subject["presence"].id).to eq user.name
       end
     end
+
+    # `TestChannel#user_presence_id` returns a non-string (`current_user.id`),
+    # and these actions join/leave with no explicit id, so the id comes from the
+    # default and must still be cast to a string for the presence proto.
+    describe "#join_presence with a non-string user_presence_id" do
+      let(:data) { {action: "follow_by_id"} }
+
+      it "casts the id to a string", :aggregate_failures do
+        expect(subject).to be_success
+        expect(subject["presence"].type).to eq "join"
+        expect(subject["presence"].id).to eq user.id.to_s
+      end
+    end
+
+    describe "#leave_presence with a non-string user_presence_id" do
+      let(:data) { {action: "unfollow_by_id"} }
+
+      it "casts the id to a string", :aggregate_failures do
+        expect(subject).to be_success
+        expect(subject["presence"].type).to eq "leave"
+        expect(subject["presence"].id).to eq user.id.to_s
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #225.

`#join_presence` casts the presence id with `#to_s`, but `#leave_presence` passes it through untouched. When `user_presence_id` returns a non-string (e.g. `current_user.id`, as the presence docs recommend), going absent raises `Invalid argument for string field 'id' (given Integer)` while the RPC serializes the `PresenceResponse` — so the leave is never published and the member lingers in the presence set until their socket disconnects.

This mirrors the cast added to `join_presence` in 5b2581d ("always cast presence id to string"), which missed the leave path.

The specs drive both join and leave through a non-string `user_presence_id` with no explicit id argument (the existing presence specs only exercise a string, which is why this went unnoticed). Reverting the one-line change fails the leave example with that error; join passes either way.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated documentation
